### PR TITLE
Reset Capybara's document between multiple requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0"]
-        rails: ["6.0", "6.1", "main"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        rails: ["6.0", "6.1", "7.0", "main"]
 
     env:
       RAILS_VERSION: "${{ matrix.rails }}"
@@ -23,6 +23,7 @@ jobs:
     - name: "Install Ruby ${{ matrix.ruby }}"
       uses: "ruby/setup-ruby@v1"
       with:
+        rubygems: "3.3.13"
         ruby-version: "${{ matrix.ruby }}"
 
     - name: "Generate lockfile"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+The noteworthy changes for each `ActionDispatch::Testing::Integration::Capybara`
+version are included here. For a complete changelog, see the [commits] for each
+version via the version links.
+
+[commits]: https://github.com/thoughtbot/action_dispatch-testing-integration-capybara/commits/main
+
+## main
+
+* Invoke [Capybara::RackTest::Browser#reset_cache!](https://github.com/teamcapybara/capybara/blob/master/lib/capybara/rack_test/browser.rb#L112-L114) while issuing multiple requests

--- a/lib/action_dispatch/testing/integration/capybara/railtie.rb
+++ b/lib/action_dispatch/testing/integration/capybara/railtie.rb
@@ -17,6 +17,14 @@ module ActionDispatch
 
                   setup do
                     integration_session.extend(Module.new do
+                      def process(*arguments, **options, &block)
+                        if @page && @page.driver.browser.respond_to?(:reset_cache!)
+                          @page.driver.browser.reset_cache!
+                        end
+
+                        super
+                      end
+
                       def page
                         @page ||= ::Capybara::Session.new(:rack_test, @app)
                       end

--- a/spec/action_dispatch/testing/integration/capybara/rspec_spec.rb
+++ b/spec/action_dispatch/testing/integration/capybara/rspec_spec.rb
@@ -10,6 +10,20 @@ RSpec.describe "Capybara extensions", type: :request do
     expect(page).to have_button "A button"
   end
 
+  it "clears page across multiple requests" do
+    post templates_path, params: { template: <<~HTML }
+      <button>Request 1</button>
+    HTML
+
+    expect(page).to have_button "Request 1"
+
+    post templates_path, params: { template: <<~HTML }
+      <button>Request 2</button>
+    HTML
+
+    expect(page).to have_button "Request 2"
+  end
+
   it "supports Capybara::Session#within" do
     post templates_path, params: { template: <<~HTML }
       <section><h1>Hello, World!</h1></section>

--- a/test/action_dispatch/testing/integration/capybara/minitest_test.rb
+++ b/test/action_dispatch/testing/integration/capybara/minitest_test.rb
@@ -10,6 +10,20 @@ class ActionDispatch::Testing::Integration::CapybaraTest < ActionDispatch::Integ
     assert_button "A button"
   end
 
+  test "clears page across multiple requests" do
+    post templates_path, params: { template: <<~HTML }
+      <button>Request 1</button>
+    HTML
+
+    assert_button "Request 1"
+
+    post templates_path, params: { template: <<~HTML }
+      <button>Request 2</button>
+    HTML
+
+    assert_button "Request 2"
+  end
+
   test "supports Capybara::Session#within" do
     post templates_path, params: { template: <<~HTML }
       <section><h1>Hello, World!</h1></section>


### PR DESCRIPTION
When invoking multiple requests in sequence, clear whatever document contents the `Capybara::Session` has cached before issuing the request.

If no request has been made, or if the intermediate response is never parsed, skip the cache clearing.